### PR TITLE
Added ability to connect to a remote IDA instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,19 @@ screen session), and connects to it using RPyC.
 
 idalink requires the following:
 
-- IDA
-- screen
+- IDA Pro
+- screen (when running on Linux)
 - libssl0.9.8:i386 (for IDA's Python version)
 
-idalink uses, but brings with it:
+idalink uses:
 - rpyc in your Python environment outside of IDA
-- rpyc in your IDA Python environment. This is actually included in the
-  repository, because it's easier.
+- rpyc in your IDA Python environment.
 
 ## Setup
 
-To setup idalink, simply replace the idal and idal64 symlinks in the
-idalink/support directory with symlinks to your actual idal and idal64
-executables.
+To setup idalink, simply replace the idal/idaw and idal64/idaw64 symlinks in
+the idalink/support directory with symlinks to your actual idal/idaw and
+idal64/idaw64 executables.
 
 ## Usage
 

--- a/idalink/__init__.py
+++ b/idalink/__init__.py
@@ -22,8 +22,9 @@
 
 # :note: RemoteIDALink and get_memory must only be exported for rpyc
 
-from .idalink import MODULE_DIR, IDA_DIR, LOGFILE, idalink, RemoteIDALink
+from .idalink import MODULE_DIR, IDA_DIR, LOGFILE, idalink, remote_idalink, \
+    RemoteIDALink, ida_spawn
 from .memory import get_memory
 
-__all__ = ['MODULE_DIR', 'IDA_DIR', 'LOGFILE', 'idalink', 'RemoteIDALink',
-           'get_memory']
+__all__ = ['MODULE_DIR', 'IDA_DIR', 'LOGFILE', 'idalink', 'remote_idalink',
+           'RemoteIDALink', 'ida_spawn', 'get_memory']


### PR DESCRIPTION
Hi Yan,

Another pull request! This time I've added a new class, `remote_idalink`, that can be used to connect to a remote machine that is already running the idalink server in IDA Pro. Basically this allows me to use idalink to talk to my Windows IDA install from a Linux machine :-) Because you're already using RPC, there aren't many changes to existing functionality. Changes are:

* Added some new exports to `__init__.py`
* Made `ida_spawn` a public function so that it can be invoked on a remote machine. To make this some-what more robust I moved the check of the IDA path into `ida_spawn` (to make sure this check always occurs)
* Added a new class, `remote_idalink`, that extends `idalink` and instead of taking a filename and path to IDA it takes a hostname/IP address and port to connect to. Ideally what I'd like to have is a single class that takes an argument like `is_remote=True`. The filename and IDA path that you provide get translated on the server (and the file copied across to the remote machine). However I haven't figured out a nice clean way to do this... Yet :-)

Any comments/feedback welcome!

Regards,
Adrian