### PR TITLE
Make the launched IDA use the right python even on macOS

### DIFF
--- a/idalink/idalink.py
+++ b/idalink/idalink.py
@@ -101,6 +101,14 @@ def ida_spawn(filename, ida_path, port=18861, mode='oneshot',
         ida_env_script = os.path.join(MODULE_DIR, 'support', 'ida_env.sh')
         command_prefix = ['screen', '-S', 'idalink-%d' % port, '-d', '-m']
 
+    if sys.platform == "darwin":
+        # If we are running in a virtual environment, which we should, we need
+        # to insert the python lib into the launched process in order for IDA 
+        # to not default back to the Apple-installed python because of the use 
+        # of paths in library identifiers on macOS.
+        if "VIRTUAL_ENV" in os.environ:
+            ida_env_script = os.path.join(MODULE_DIR, 'support', 'ida_macos_env.sh')
+
     command = [
         ida_env_script,
         ida_realpath,

--- a/idalink/support/ida_macos_env.sh
+++ b/idalink/support/ida_macos_env.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright (C) 2013- Yan Shoshitaishvili aka. zardus
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+export TERM=xterm
+export _DYLD_INSERT_LIBRARIES=$VIRTUAL_ENV/.Python
+
+IDA="$1"
+shift
+DYLD_INSERT_LIBRARIES=$_DYLD_INSERT_LIBRARIES "$IDA" "$@"


### PR DESCRIPTION
Dynamic linking on OS X/macOS is "special" and so are python installations. Each dynamic library has an embedded identifier that typically includes a file path. This is e.g. what the (link) in my `ida` virtualenv looks like:
```
$ otool -D .Python
.Python:
/Library/Frameworks/Python.framework/Versions/2.7/Python
```
which is supposed to match the dependencies
```
$ otool -L python.pmc64
python.pmc64:
	@executable_path/plugins/python.pmc64 (compatibility version 1.0.0, current version 1.0.0)
	@executable_path/libida64.dylib (compatibility version 1.0.0, current version 1.0.0)
        ...
	/Library/Frameworks/Python.framework/Versions/2.7/Python (compatibility version 2.7.0, current version 2.7.1)
```
`python` in turn appears to pick up its prefix from where the shared library was loaded from and I have been able to get `dyld` to load it on demand. Pre-inserting it seems to work though.