### PR TITLE
add support for newer ida modules required for ida 7.4^

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea


### PR DESCRIPTION
Since IDA is deprecating most of the standard APIs in idc, idaapi and etc..
Iv'e added some of the required modules to access the new API. tested and works :)

See Also:
https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml

